### PR TITLE
feat: Add foreign key handling to delta load strategy

### DIFF
--- a/src/py_load_opentargets/loader.py
+++ b/src/py_load_opentargets/loader.py
@@ -24,6 +24,36 @@ class DatabaseLoader(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def get_foreign_keys(self, table_name: str) -> List[Dict[str, str]]:
+        """
+        Retrieve definitions for all foreign key constraints on a table.
+
+        :param table_name: The fully qualified name of the table.
+        :return: A list of dicts, where each dict has 'name' and 'ddl' for a constraint.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def drop_foreign_keys(self, table_name: str, foreign_keys: List[Dict[str, str]]) -> None:
+        """
+        Drops a list of foreign key constraints.
+
+        :param table_name: The fully qualified name of the table.
+        :param foreign_keys: A list of FK definition dicts, e.g., from get_foreign_keys.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def recreate_foreign_keys(self, table_name: str, foreign_keys: List[Dict[str, str]]) -> None:
+        """
+        Recreates a list of foreign key constraints from their DDL definitions.
+
+        :param table_name: The fully qualified name of the table.
+        :param foreign_keys: A list of FK definition dicts, e.g., from get_foreign_keys.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def cleanup(self) -> None:
         """
         Perform cleanup operations, like closing connections.

--- a/tests/test_foreign_key_handling.py
+++ b/tests/test_foreign_key_handling.py
@@ -1,0 +1,95 @@
+import pytest
+from testcontainers.postgres import PostgresContainer
+import psycopg
+from psycopg import sql
+
+from py_load_opentargets.backends.postgres import PostgresLoader
+
+@pytest.fixture(scope="module")
+def postgres_container():
+    """Starts a PostgreSQL container for the test module."""
+    with PostgresContainer("postgres:16") as container:
+        yield container
+
+@pytest.fixture
+def db_loader(postgres_container: PostgresContainer):
+    """Provides a connected PostgresLoader instance for each test."""
+    conn_str = postgres_container.get_connection_url().replace("+psycopg2", "")
+    loader = PostgresLoader()
+    loader.connect(conn_str)
+
+    # Setup initial schema
+    setup_sql = """
+    CREATE TABLE public.parent (
+        id INT PRIMARY KEY
+    );
+    CREATE TABLE public.child (
+        id INT PRIMARY KEY,
+        parent_id INT
+    );
+    INSERT INTO public.parent (id) VALUES (1), (2);
+    INSERT INTO public.child (id, parent_id) VALUES (10, 1), (20, 2);
+
+    ALTER TABLE public.child
+    ADD CONSTRAINT fk_child_parent
+    FOREIGN KEY (parent_id) REFERENCES public.parent(id);
+    """
+    loader.cursor.execute(setup_sql)
+    loader.conn.commit()
+
+    yield loader
+
+    # Teardown
+    loader.cursor.execute("DROP TABLE IF EXISTS public.child; DROP TABLE IF EXISTS public.parent;")
+    loader.conn.commit()
+    loader.cleanup()
+
+def test_get_foreign_keys(db_loader: PostgresLoader):
+    """Tests that foreign keys are correctly identified."""
+    fks = db_loader.get_foreign_keys("public.child")
+    assert len(fks) == 1
+    fk = fks[0]
+    assert fk["name"] == "fk_child_parent"
+    # DDL from pg_get_constraintdef might not be schema-qualified, so test is less strict.
+    assert "FOREIGN KEY (parent_id) REFERENCES parent(id)" in fk["ddl"]
+
+def test_drop_and_recreate_foreign_keys(db_loader: PostgresLoader):
+    """
+    Tests the full drop and recreate cycle of foreign keys.
+    """
+    table_name = "public.child"
+
+    # 1. Get the foreign keys
+    fks = db_loader.get_foreign_keys(table_name)
+    assert len(fks) == 1
+
+    # 2. Drop the foreign keys
+    db_loader.drop_foreign_keys(table_name, fks)
+
+    # 3. Verify FK is dropped by inserting an orphan row (should succeed)
+    try:
+        db_loader.cursor.execute("INSERT INTO public.child (id, parent_id) VALUES (30, 99);")
+        db_loader.conn.commit()
+    except psycopg.errors.ForeignKeyViolation:
+        pytest.fail("ForeignKeyViolation was raised, but constraint should have been dropped.")
+
+    # 4. Clean up the orphan row before recreating the constraint
+    db_loader.cursor.execute("DELETE FROM public.child WHERE id = 30;")
+    db_loader.conn.commit()
+
+    # 5. Recreate the foreign keys
+    db_loader.recreate_foreign_keys(table_name, fks)
+
+    # 6. Verify FK is recreated by inserting another orphan row (should fail)
+    with pytest.raises(psycopg.errors.ForeignKeyViolation):
+        db_loader.cursor.execute("INSERT INTO public.child (id, parent_id) VALUES (40, 101);")
+        db_loader.conn.commit()
+
+    # The transaction is now in a failed state, so we must roll it back
+    # before the fixture can clean up the tables.
+    db_loader.conn.rollback()
+
+def test_get_foreign_keys_no_fks(db_loader: PostgresLoader):
+    """Tests that an empty list is returned for a table with no FKs."""
+    fks = db_loader.get_foreign_keys("public.parent")
+    assert len(fks) == 0


### PR DESCRIPTION
This commit introduces the capability to drop and recreate foreign key constraints during the delta load process, as specified in the FRD for performance optimization.

The changes include:
- Extended the `DatabaseLoader` interface with abstract methods for `get_foreign_keys`, `drop_foreign_keys`, and `recreate_foreign_keys`.
- Implemented these methods in the `PostgresLoader`, using queries against `pg_constraint` to manage foreign key definitions.
- Integrated the calls into the `ETLOrchestrator` to disable foreign keys before the merge operation and re-enable them in a `finally` block, ensuring they are always reapplied.
- Added a new integration test suite (`test_foreign_key_handling.py`) using `testcontainers` to validate the entire lifecycle of foreign key management.