### PR TITLE
feat: Add a 'validate' command to the CLI

### DIFF
--- a/src/py_load_opentargets/validator.py
+++ b/src/py_load_opentargets/validator.py
@@ -1,0 +1,91 @@
+import os
+import logging
+from typing import Dict, Any
+
+import psycopg
+import fsspec
+
+from .data_acquisition import list_available_versions
+
+logger = logging.getLogger(__name__)
+
+
+class ValidationService:
+    """A service to run validation checks on the configuration and connections."""
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+
+    def run_all_checks(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Runs all validation checks and returns a dictionary of results.
+        """
+        results = {
+            "Database Connection": self.check_db_connection(),
+            "Data Source Connection": self.check_source_connection(),
+            "Dataset Definitions": self.check_dataset_definitions(),
+        }
+        return results
+
+    def check_db_connection(self) -> Dict[str, Any]:
+        """
+        Checks if a connection to the database can be established.
+        """
+        db_conn_str = os.getenv("DB_CONN_STR")
+        if not db_conn_str:
+            return {"success": False, "message": "DB_CONN_STR environment variable not set."}
+
+        try:
+            # Hide password from logs
+            hidden_conn_str = str(psycopg.conninfo.make_conninfo(db_conn_str))
+            logger.info(f"Attempting to connect to database: {hidden_conn_str}")
+            with psycopg.connect(db_conn_str) as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute("SELECT 1;")
+                    result = cursor.fetchone()
+                    if result and result[0] == 1:
+                        return {"success": True, "message": "Database connection successful."}
+                    else:
+                        return {"success": False, "message": "Connection established, but test query failed."}
+        except Exception as e:
+            error_msg = str(e).split('\n')[0] # Get the first line of the error
+            logger.error(f"Database connection failed: {error_msg}")
+            return {"success": False, "message": f"Failed to connect: {error_msg}"}
+
+    def check_source_connection(self) -> Dict[str, Any]:
+        """
+        Checks if the remote data source is accessible and contains valid versions.
+        """
+        discovery_uri = self.config.get("source", {}).get("version_discovery_uri")
+        if not discovery_uri:
+            return {"success": False, "message": "Missing 'version_discovery_uri' in config."}
+
+        try:
+            logger.info(f"Attempting to discover versions at: {discovery_uri}")
+            versions = list_available_versions(discovery_uri)
+            if versions:
+                return {"success": True, "message": f"Successfully found versions (latest: {versions[0]})."}
+            else:
+                return {"success": False, "message": f"Could not find any versions at '{discovery_uri}'."}
+        except Exception as e:
+            error_msg = str(e).split('\n')[0]
+            logger.error(f"Source connection failed: {error_msg}")
+            return {"success": False, "message": f"Failed to connect to source: {error_msg}"}
+
+    def check_dataset_definitions(self) -> Dict[str, Any]:
+        """
+        Checks if all configured datasets have a primary key defined.
+        """
+        datasets = self.config.get("datasets", {})
+        if not datasets:
+            return {"success": False, "message": "'datasets' section is missing or empty in config."}
+
+        missing_pk = []
+        for name, conf in datasets.items():
+            if not conf.get("primary_key"):
+                missing_pk.append(name)
+
+        if missing_pk:
+            return {"success": False, "message": f"Datasets missing 'primary_key': {', '.join(missing_pk)}"}
+        else:
+            return {"success": True, "message": "All dataset definitions are valid."}

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,124 @@
+import os
+import pytest
+import psycopg
+from unittest.mock import MagicMock
+
+from py_load_opentargets.validator import ValidationService
+
+
+@pytest.fixture
+def minimal_config():
+    """A minimal, valid config for testing."""
+    return {
+        "source": {
+            "version_discovery_uri": "gs://open-targets/platform/"
+        },
+        "datasets": {
+            "targets": {"primary_key": ["id"]},
+            "diseases": {"primary_key": ["id"]}
+        }
+    }
+
+
+def test_check_db_connection_success(mocker):
+    """Test successful database connection validation."""
+    mocker.patch('os.getenv', return_value="postgresql://user:pass@host/db")
+    mock_connect = mocker.patch('psycopg.connect')
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.return_value = (1,)
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+    mock_connect.return_value.__enter__.return_value = mock_conn
+
+    validator = ValidationService({})
+    result = validator.check_db_connection()
+
+    assert result["success"] is True
+    assert "successful" in result["message"]
+
+
+def test_check_db_connection_failure_no_env(mocker):
+    """Test failure when DB_CONN_STR is not set."""
+    mocker.patch('os.getenv', return_value=None)
+    validator = ValidationService({})
+    result = validator.check_db_connection()
+
+    assert result["success"] is False
+    assert "not set" in result["message"]
+
+
+def test_check_db_connection_failure_exception(mocker):
+    """Test failure when psycopg.connect raises an exception."""
+    mocker.patch('os.getenv', return_value="postgresql://user:pass@host/db")
+    mocker.patch('psycopg.connect', side_effect=psycopg.OperationalError("Test connection error"))
+
+    validator = ValidationService({})
+    result = validator.check_db_connection()
+
+    assert result["success"] is False
+    assert "Test connection error" in result["message"]
+
+
+def test_check_source_connection_success(mocker, minimal_config):
+    """Test successful source connection validation."""
+    mocker.patch('py_load_opentargets.validator.list_available_versions', return_value=['24.06', '24.03'])
+    validator = ValidationService(minimal_config)
+    result = validator.check_source_connection()
+
+    assert result["success"] is True
+    assert "24.06" in result["message"]
+
+
+def test_check_source_connection_failure_no_versions(mocker, minimal_config):
+    """Test failure when no versions are found."""
+    mocker.patch('py_load_opentargets.validator.list_available_versions', return_value=[])
+    validator = ValidationService(minimal_config)
+    result = validator.check_source_connection()
+
+    assert result["success"] is False
+    assert "Could not find any versions" in result["message"]
+
+
+def test_check_source_connection_failure_exception(mocker, minimal_config):
+    """Test failure when list_available_versions raises an exception."""
+    mocker.patch('py_load_opentargets.validator.list_available_versions', side_effect=Exception("Test source error"))
+    validator = ValidationService(minimal_config)
+    result = validator.check_source_connection()
+
+    assert result["success"] is False
+    assert "Test source error" in result["message"]
+
+
+def test_check_dataset_definitions_success(minimal_config):
+    """Test successful dataset definition validation."""
+    validator = ValidationService(minimal_config)
+    result = validator.check_dataset_definitions()
+
+    assert result["success"] is True
+    assert "valid" in result["message"]
+
+
+def test_check_dataset_definitions_failure_missing_pk():
+    """Test failure when a dataset is missing a primary_key."""
+    invalid_config = {
+        "datasets": {
+            "targets": {"primary_key": ["id"]},
+            "diseases": {} # Missing primary_key
+        }
+    }
+    validator = ValidationService(invalid_config)
+    result = validator.check_dataset_definitions()
+
+    assert result["success"] is False
+    assert "diseases" in result["message"]
+    assert "targets" not in result["message"]
+
+
+def test_check_dataset_definitions_failure_no_datasets():
+    """Test failure when the datasets section is empty."""
+    invalid_config = {"datasets": {}}
+    validator = ValidationService(invalid_config)
+    result = validator.check_dataset_definitions()
+
+    assert result["success"] is False
+    assert "missing or empty" in result["message"]


### PR DESCRIPTION
This commit introduces a new `validate` command to the `py_load_opentargets` CLI. This command provides a pre-flight check to verify user configuration and connectivity before initiating a full data load.

The `validate` command performs the following checks:
- Verifies that the `DB_CONN_STR` environment variable is set and that a connection to the database can be established.
- Checks that the `version_discovery_uri` in the configuration is accessible and that Open Targets versions can be discovered.
- Ensures that all datasets defined in the configuration have a `primary_key` specified.

This feature improves the tool's usability and reliability by allowing users to quickly diagnose setup issues without starting a long-running process.

Implementation Details:
- A new `ValidationService` class is created in `src/py_load_opentargets/validator.py` to encapsulate the validation logic.
- The new command is integrated into `src/py_load_opentargets/cli.py`.
- Comprehensive unit tests for the `ValidationService` and integration tests for the new CLI command have been added.