### PR TITLE
feat: Implement flexible schema mapping with schema_overrides

### DIFF
--- a/src/py_load_opentargets/default_config.toml
+++ b/src/py_load_opentargets/default_config.toml
@@ -37,9 +37,19 @@ data_download_uri_template = "gcs://open-targets/platform/{version}/output/etl/p
 
 [datasets.targets]
 primary_key = ["id"]
-# A list of struct columns to flatten. Each sub-field in the struct
-# will become a new column, named 'struct_name_separator_field_name'.
-flatten_structs = ["genomicLocation", "tep"]
+# The 'schema_overrides' table provides fine-grained control over how columns
+# are processed and mapped to the database schema.
+[datasets.targets.schema_overrides]
+  # For the 'id' column, rename it to 'target_id' in the final table.
+  id = { rename = "target_id" }
+  # The 'tep' column is a struct. 'action = "flatten"' will expand its
+  # sub-fields (e.g., 'uri', 'name') into new columns ('tep_uri', 'tep_name').
+  tep = { action = "flatten" }
+  # 'genomicLocation' is also a struct to be flattened.
+  genomicLocation = { action = "flatten" }
+  # 'obsoleteTerms' is an array of structs. 'action = "json"' will serialize
+  # the entire array into a single JSONB column for flexible querying.
+  obsoleteTerms = { action = "json" }
 
 [datasets.diseases]
 primary_key = ["id"]

--- a/tests/test_schema_mapping.py
+++ b/tests/test_schema_mapping.py
@@ -1,0 +1,147 @@
+import pytest
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+import polars as pl
+
+from src.py_load_opentargets.backends.postgres import PostgresLoader, _ParquetStreamer
+
+@pytest.fixture(scope="module")
+def complex_parquet_file(tmp_path_factory) -> Path:
+    """
+    Creates a parquet file with a complex schema for testing transformations.
+    This fixture has 'module' scope to avoid recreating the file for every test function.
+    """
+    tmp_dir = tmp_path_factory.mktemp("data")
+    file_path = tmp_dir / "test_complex.parquet"
+
+    # Define a schema with nested structs and lists
+    schema = pa.schema([
+        pa.field("id", pa.string(), metadata={"description": "The main ID"}),
+        pa.field("info", pa.struct([
+            pa.field("name", pa.string()),
+            pa.field("license", pa.string())
+        ])),
+        pa.field("annotations", pa.struct([
+            pa.field("source", pa.string()),
+            pa.field("url", pa.string())
+        ])),
+        pa.field("tags", pa.list_(pa.string())),
+        pa.field("numeric_score", pa.float64())
+    ])
+
+    # Create some data
+    data = pa.Table.from_pydict({
+        "id": ["a-1"],
+        "info": [{"name": "Test Data", "license": "CC0"}],
+        "annotations": [{"source": "internal", "url": "http://example.com"}],
+        "tags": [["tag1", "tag2"]],
+        "numeric_score": [99.9]
+    }, schema=schema)
+
+    pq.write_table(data, file_path)
+    return file_path
+
+def test_get_transformed_schema_rename_and_flatten(complex_parquet_file):
+    """
+    Tests that the schema transformation correctly renames a column and flattens a struct.
+    """
+    loader = PostgresLoader()
+    loader.dataset_config = {
+        "schema_overrides": {
+            "id": {"rename": "test_id"},
+            "info": {"action": "flatten"}
+        },
+        "flatten_separator": "__" # Use a distinct separator for testing
+    }
+
+    original_schema = pq.read_schema(complex_parquet_file)
+    transformed_schema = loader._get_transformed_schema(original_schema)
+
+    # Check that 'id' was renamed to 'test_id'
+    assert "test_id" in transformed_schema.names
+    assert "id" not in transformed_schema.names
+    assert transformed_schema.field("test_id").type == pa.string()
+
+    # Check that 'info' was flattened
+    assert "info__name" in transformed_schema.names
+    assert "info__license" in transformed_schema.names
+    assert "info" not in transformed_schema.names
+
+    # Check that other fields are preserved
+    assert "annotations" in transformed_schema.names
+    assert "tags" in transformed_schema.names
+
+def test_get_transformed_schema_json_serialization():
+    """
+    Tests that the schema transformation preserves nested types when the
+    action is 'json', allowing them to be mapped to JSONB.
+    """
+    loader = PostgresLoader()
+    loader.dataset_config = {
+        "schema_overrides": {
+            "annotations": {"action": "json"},
+            "tags": {"action": "json"}
+        }
+    }
+
+    original_schema = pa.schema([
+        pa.field("annotations", pa.struct([pa.field("source", pa.string())])),
+        pa.field("tags", pa.list_(pa.string()))
+    ])
+
+    transformed_schema = loader._get_transformed_schema(original_schema)
+
+    # The types should be preserved, not converted to string.
+    assert pa.types.is_struct(transformed_schema.field("annotations").type)
+    assert pa.types.is_list(transformed_schema.field("tags").type)
+
+def test_parquet_streamer_with_transformations(complex_parquet_file):
+    """
+    Tests the end-to-end data transformation through the _ParquetStreamer.
+    """
+    schema_overrides = {
+        "id": {"rename": "test_id"},
+        "info": {"action": "flatten"},
+        "annotations": {"action": "json"},
+        "tags": {"action": "json"}
+    }
+    flatten_separator = "_"
+
+    original_schema = pq.read_schema(complex_parquet_file)
+
+    streamer = _ParquetStreamer(
+        paths=[str(complex_parquet_file)],
+        original_schema=original_schema,
+        schema_overrides=schema_overrides,
+        flatten_separator=flatten_separator,
+    )
+
+    # Read the entire stream content
+    stream_content = streamer.read()
+
+    # The output is TSV, so we can parse it
+    # Expected header based on transformations:
+    # test_id, info_name, info_license, annotations, tags, numeric_score
+
+    # Polars can read the TSV result for easy validation
+    result_df = pl.read_csv(
+        source=stream_content.encode(),
+        separator='\t',
+        has_header=False,
+        new_columns=[
+            "test_id", "info_name", "info_license", "annotations", "tags", "numeric_score"
+        ]
+    )
+
+    assert result_df.shape == (1, 6)
+    row = result_df.row(0, named=True)
+
+    assert row["test_id"] == "a-1"
+    assert row["info_name"] == "Test Data"
+    assert row["info_license"] == "CC0"
+    # Polars stringifies nested types when reading from Parquet,
+    # so the JSON strings should match this behavior.
+    assert row["annotations"] == '{"source":"internal","url":"http://example.com"}'
+    assert row["tags"] == '["tag1","tag2"]'
+    assert row["numeric_score"] == 99.9


### PR DESCRIPTION
This commit introduces a flexible and powerful schema mapping system by replacing the limited `flatten_structs` configuration with a more expressive `schema_overrides` table.

Key changes:
- **New `schema_overrides` config:** Users can now define per-column rules for renaming, flattening structs, and serializing nested types to JSON.
- **Refactored `PostgresLoader`:** The data loading logic was updated to dynamically build Polars expressions based on the new configuration, allowing for on-the-fly data transformation during streaming.
- **Updated Tests:** The test suite has been significantly updated. Old tests were refactored to use the new configuration, and a new test file (`test_schema_mapping.py`) was added to specifically validate the different transformation rules.
- **Updated Documentation:** The `configuration.md` file has been updated to document the new `schema_overrides` feature with clear examples.

This change addresses the gap in the FRD for a more robust strategy for handling nested data, making the package significantly more flexible for end-users.