### PR TITLE
feat: Add S3 support for data discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "fsspec[gcs]",
+    "fsspec",
     "pyarrow",
     "polars",
     "psycopg[binary]",
@@ -30,11 +30,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+gcs = ["gcsfs"]
+s3 = ["s3fs"]
+all_cloud = ["gcsfs", "s3fs"]
 test = [
     "pytest",
     "testcontainers[postgres]",
     "pytest-mock",
     "ruff",
+    "moto[s3]",
+    "boto3",
 ]
 docs = [
     "mkdocs",

--- a/tests/test_s3_support.py
+++ b/tests/test_s3_support.py
@@ -1,0 +1,48 @@
+import pytest
+import boto3
+from moto import mock_aws
+
+from src.py_load_opentargets.data_acquisition import list_available_versions
+
+
+@pytest.fixture
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    import os
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+
+@pytest.fixture
+def s3_bucket(aws_credentials):
+    """Create a mock S3 bucket and populate it with version-like folders."""
+    with mock_aws():
+        bucket_name = "mock-opentargets-bucket"
+        s3 = boto3.client("s3")
+        s3.create_bucket(Bucket=bucket_name)
+
+        # Create objects that simulate directories
+        s3.put_object(Bucket=bucket_name, Key="platform/24.06/")
+        s3.put_object(Bucket=bucket_name, Key="platform/24.09/")
+        s3.put_object(Bucket=bucket_name, Key="platform/23.12/")
+        s3.put_object(Bucket=bucket_name, Key="platform/README.md") # A file to be ignored
+
+        yield bucket_name
+
+
+def test_list_versions_from_s3(s3_bucket):
+    """
+    Verify that list_available_versions can discover versions from an S3 bucket.
+    """
+    # Arrange
+    bucket_name = s3_bucket
+    discovery_uri = f"s3://{bucket_name}/platform/"
+
+    # Act
+    versions = list_available_versions(discovery_uri)
+
+    # Assert
+    assert versions == ["24.09", "24.06", "23.12"]


### PR DESCRIPTION
This change introduces support for discovering Open Targets data versions from AWS S3 buckets.

To enhance the cloud-agnostic nature of the package, the cloud-specific file system dependencies have been moved to optional extras in `pyproject.toml`. Users can now install support for GCS or S3 as needed via `pip install .[gcs]` or `pip install .[s3]`.

A new integration test using the `moto` library has been added to mock S3 services. This test verifies that the `list_available_versions` function correctly works with `s3://` URIs without any changes to the function itself, proving the effectiveness of the underlying `fsspec` abstraction.