### PR TITLE
feat: Document S3 support and fix test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This tool allows you to download and load the entire Open Targets platform datas
 
 - **Configuration-Driven**: Control the entire loading process with a simple `config.toml` file.
 - **Extensible**: Supports multiple database backends through a pluggable system (currently supports PostgreSQL).
+- **Multi-Source**: Natively handles data from GCS, FTP, and S3-compatible storage using a unified interface.
 - **High Performance**: Uses native database bulk loading (`COPY` for PostgreSQL) for maximum speed.
 - **Idempotent**: Safely re-run loads for the same version without creating duplicate data.
 - **Schema-Aware**: Automatically creates tables, infers schemas, and handles schema evolution between releases.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,37 @@ This section tells the loader where to find the Open Targets data releases.
 
 ---
 
+### Using S3 as a Data Source
+
+The loader can be configured to use any `fsspec`-compatible backend, including Amazon S3. To use data stored in a private or public S3 bucket, follow these steps:
+
+1.  **Install S3 support:**
+    You must install the package with the `s3` extra, which includes the `s3fs` library.
+    ```bash
+    pip install py_load_opentargets[s3]
+    ```
+
+2.  **Configure AWS Credentials:**
+    Your environment must be configured with AWS credentials. The most common method is to set the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_SESSION_TOKEN` environment variables.
+
+3.  **Update your `config.toml`:**
+    In your configuration file, you need to change the `[source]` URIs to point to your S3 bucket. You can comment out the default URIs and replace them with your S3 paths.
+
+    ```toml
+    [source]
+    # Default URIs (comment these out)
+    # version_discovery_uri = "ftp://ftp.ebi.ac.uk/pub/databases/opentargets/platform/"
+    # checksum_uri_template = "ftp://ftp.ebi.ac.uk/pub/databases/opentargets/platform/{version}/"
+    # data_download_uri_template = "gcs://open-targets/platform/{version}/output/etl/parquet/{dataset_name}/"
+
+    # S3 URIs (uncomment and edit these)
+    version_discovery_uri = "s3://your-opentargets-bucket/platform/"
+    checksum_uri_template = "s3://your-opentargets-bucket/platform/{version}/"
+    data_download_uri_template = "s3://your-opentargets-bucket/platform/{version}/output/etl/parquet/{dataset_name}/"
+    ```
+
+---
+
 ## `[database]`
 
 This section controls database-specific behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ test = [
     "ruff",
     "moto[s3]",
     "boto3",
+    "s3fs",
 ]
 docs = [
     "mkdocs",

--- a/src/py_load_opentargets/default_config.toml
+++ b/src/py_load_opentargets/default_config.toml
@@ -29,6 +29,20 @@ checksum_uri_template = "ftp://ftp.ebi.ac.uk/pub/databases/opentargets/platform/
 data_download_uri_template = "gcs://open-targets/platform/{version}/output/etl/parquet/{dataset_name}/"
 
 
+# --- S3 Data Source Example ---
+# To use a private S3 bucket as the data source, comment out the default URIs
+# above and uncomment the lines below.
+#
+# You must also install the S3 dependency: pip install .[s3]
+#
+# Your environment must be configured with AWS credentials (e.g., via environment
+# variables AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY).
+#
+# version_discovery_uri = "s3://your-opentargets-bucket/platform/"
+# checksum_uri_template = "s3://your-opentargets-bucket/platform/{version}/"
+# data_download_uri_template = "s3://your-opentargets-bucket/platform/{version}/output/etl/parquet/{dataset_name}/"
+
+
 # Definitions for each dataset to be loaded.
 # Each dataset needs a 'primary_key' list for the merge (UPSERT) operation.
 # An optional 'final_table_name' can be provided to override the default,


### PR DESCRIPTION
Adds documentation and configuration examples to make the existing S3 data source capability more accessible to users.

- Adds a commented-out example for S3 configuration to `default_config.toml`.
- Updates `README.md` to list multi-source support as a key feature.
- Adds a new section to `docs/configuration.md` with detailed instructions on how to configure the loader for S3, including installing the necessary `s3fs` dependency.

Additionally, this change fixes a bug in the test setup where the `s3fs` library was missing from the `[test]` extras in `pyproject.toml`, causing S3-related tests to fail.