### PR TITLE
feat: Integrate pre-flight validator into load command

### DIFF
--- a/src/py_load_opentargets/cli.py
+++ b/src/py_load_opentargets/cli.py
@@ -99,6 +99,24 @@ def load(ctx, version, staging_schema, final_schema, skip_confirmation, no_conti
     click.echo(f"Selected datasets: {click.style(', '.join(datasets_to_process), bold=True)}")
     click.echo(f"Load type: {click.style(load_type, bold=True)}")
 
+    # Run validation checks before proceeding
+    click.echo("Validating configuration and connections...")
+    validator = ValidationService(config)
+    results = validator.run_all_checks()
+    all_successful = True
+    for check_name, result in results.items():
+        if not result["success"]:
+            all_successful = False
+            message = result["message"]
+            click.secho(f"Validation FAILED for '{check_name}': {message}", fg='red')
+
+    if not all_successful:
+        click.secho("Prerequisite validation failed. Please check your configuration.", fg='red', bold=True)
+        raise click.Abort()
+    else:
+        click.echo(click.style("Validation successful.", fg='green'))
+
+
     if not version:
         click.echo("Discovering the latest version...")
         try:


### PR DESCRIPTION
Integrates the existing `ValidationService` into the main `load` command's execution flow.

This change improves user experience by running a series of pre-flight checks before starting the main ETL process:
- Verifies database connectivity.
- Checks that the data source is reachable.
- Ensures all configured datasets have a primary key.

If any check fails, the process aborts with a clear error message, preventing the loader from failing with a less helpful error mid-process.

A new integration test has been added to verify that the `load` command fails gracefully with an invalid configuration.

Additionally, this change includes a fix for a brittle, pre-existing unit test (`test_align_final_table_schema_detects_all_drift_types`) that was causing persistent CI failures. The assertion was updated to be more robust by inspecting the structure of the generated SQL object rather than attempting to render it to a string.