### PR TITLE
Refactor config handling and fix path joining bug

### DIFF
--- a/src/py_load_opentargets/data_acquisition.py
+++ b/src/py_load_opentargets/data_acquisition.py
@@ -95,6 +95,9 @@ def get_checksum_manifest(version: str, checksum_uri_template: str) -> Dict[str,
     :return: A dictionary mapping file paths to their expected SHA1 checksums.
     """
     release_uri = checksum_uri_template.format(version=version)
+    # Ensure the URI has a trailing slash for correct path joining
+    if not release_uri.endswith('/'):
+        release_uri += '/'
     manifest_path = f"{release_uri}release_data_integrity"
     checksum_for_manifest_path = f"{manifest_path}.sha1"
     logger.info(f"Downloading checksum manifest from {release_uri}")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -20,9 +20,12 @@ class TestETLOrchestrator(unittest.TestCase):
                 'backend': 'postgres'
             },
             'source': {
-                'data_uri_template': 'http://fake/{version}/{dataset_name}',
-                'data_download_uri_template': 'gcs://fake-bucket/{version}/{dataset_name}/',
-                'checksum_uri_template': 'gcs://fake-checksums/{version}/'
+                'provider': 'gcs_ftp',
+                'gcs_ftp': {
+                    'data_uri_template': 'http://fake/{version}/{dataset_name}',
+                    'data_download_uri_template': 'gcs://fake-bucket/{version}/{dataset_name}/',
+                    'checksum_uri_template': 'gcs://fake-checksums/{version}/'
+                }
             },
             'datasets': {
                 'targets': {


### PR DESCRIPTION
This commit introduces two main improvements to the codebase:

1.  **Refactored Source Configuration Handling:** The ETL orchestrator has been updated to support multiple data source "providers" (e.g., 'gcs_ftp', 's3', 'local'). It now correctly reads the active provider from the configuration and uses the corresponding nested configuration block. This makes the data source handling more robust and extensible, aligning with the project's architectural goals. This change also required updating the mock configuration in the orchestrator's unit tests.

2.  **Fixed Path Joining in Data Acquisition:** A bug was fixed in the `get_checksum_manifest` function where it would fail to construct correct file paths if the provided URI template did not have a trailing slash. The function now ensures the URI ends with a slash before appending filenames, making it more resilient.