### PR TITLE
feat: Integrate structured JSON logging

### DIFF
--- a/src/py_load_opentargets/cli.py
+++ b/src/py_load_opentargets/cli.py
@@ -12,16 +12,22 @@ from .validator import ValidationService
 logger = logging.getLogger(__name__)
 
 
+from .logging_utils import setup_logging
+
 @click.group()
 @click.option('--config', 'config_path', type=click.Path(exists=True), help='Path to a custom config.toml file.')
+@click.option('--json-logs', is_flag=True, help='Output logs in JSON format. Overrides config file setting.')
 @click.pass_context
-def cli(ctx, config_path):
+def cli(ctx, config_path, json_logs):
     """A CLI tool to download and load Open Targets data."""
-    setup_logging()
     ctx.ensure_object(dict)
-    # Load config and attach it to the click context
-    # This also populates the new 'database' section with defaults if not present
-    ctx.obj['CONFIG'] = load_config(config_path)
+    config = load_config(config_path)
+    ctx.obj['CONFIG'] = config
+
+    # Setup logging
+    # The CLI flag --json-logs takes precedence over the config file setting.
+    use_json_logging = json_logs or config.get('logging', {}).get('json_format', False)
+    setup_logging(json_format=use_json_logging)
 
 
 @cli.command(name="list-versions")

--- a/src/py_load_opentargets/default_config.toml
+++ b/src/py_load_opentargets/default_config.toml
@@ -6,6 +6,11 @@
 # A value of 1 means sequential processing.
 max_workers = 4
 
+[logging]
+# Set to true to output logs in a structured JSON format.
+# This can be overridden by the --json-logs flag in the CLI.
+json_format = false
+
 [database]
 # The name of the database backend to use.
 # This must match an entry point in the 'py_load_opentargets.backends' group.

--- a/src/py_load_opentargets/logging_utils.py
+++ b/src/py_load_opentargets/logging_utils.py
@@ -2,42 +2,46 @@ import logging
 import sys
 from pythonjsonlogger import jsonlogger
 
-def setup_logging():
+def setup_logging(level=logging.INFO, json_format=False):
     """
-    Sets up structured JSON logging for the application.
+    Configures the root logger for the application.
 
-    This function configures the root logger to output logs in JSON format
-    to standard output. It removes any existing handlers to ensure that
-    only the JSON handler is used.
+    This function can set up either standard text logging or structured
+    JSON logging based on the 'json_format' parameter. It removes any
+    existing handlers to ensure a clean setup.
     """
     logger = logging.getLogger()
+    logger.setLevel(level)
 
     # Remove any existing handlers to avoid duplicate logs
     if logger.hasHandlers():
         logger.handlers.clear()
 
     # Create a handler that writes to stdout
-    log_handler = logging.StreamHandler(sys.stdout)
+    handler = logging.StreamHandler(sys.stdout)
 
-    # Create a JSON formatter and add it to the handler
-    # The format string defines the fields that will be in the JSON output.
-    formatter = jsonlogger.JsonFormatter(
-        '%(asctime)s %(name)s %(levelname)s %(message)s'
-    )
-    log_handler.setFormatter(formatter)
+    if json_format:
+        # Use a JSON formatter
+        formatter = jsonlogger.JsonFormatter(
+            '%(asctime)s %(name)s %(levelname)s %(message)s'
+        )
+        handler.setFormatter(formatter)
+        log_message = "Structured JSON logging initialized."
+    else:
+        # Use a standard text formatter
+        formatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        )
+        handler.setFormatter(formatter)
+        log_message = "Standard text logging initialized."
 
-    # Add the handler to the root logger
-    logger.addHandler(log_handler)
-
-    # Set the default logging level
-    logger.setLevel(logging.INFO)
+    # Add the configured handler to the root logger
+    logger.addHandler(handler)
 
     # Redirect warnings from the 'warnings' module to the logging system
     logging.captureWarnings(True)
-
-    # Also configure the root logger for the warnings module
     warnings_logger = logging.getLogger('py.warnings')
-    warnings_logger.addHandler(log_handler)
+    warnings_logger.addHandler(handler)
     warnings_logger.setLevel(logging.WARNING)
 
-    logging.getLogger(__name__).info("Structured JSON logging initialized.")
+    logging.getLogger(__name__).info(log_message)


### PR DESCRIPTION
This commit introduces a structured JSON logging feature to the application, which can be enabled via a command-line flag or a configuration file setting.

The main changes are:
- A `--json-logs` flag is added to the CLI.
- A `logging.json_format` option is added to `config.toml`. The CLI flag takes precedence.
- The `setup_logging` utility is updated to dynamically select between a standard text formatter and a `JsonFormatter`.
- Integration tests are added to validate the new functionality.
- A bug in the test suite related to monkeypatching the validation module was fixed to prevent real network calls during tests.