### PR TITLE
feat: Add detailed vignette for using the package

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,107 @@
+# Default configuration for the Open Targets data loader.
+# Users can override these settings by creating their own config.toml.
+
+[execution]
+# The number of parallel threads to use for downloading and processing datasets.
+# A value of 1 means sequential processing.
+max_workers = 4
+
+[logging]
+# Set to true to output logs in a structured JSON format.
+# This can be overridden by the --json-logs flag in the CLI.
+json_format = false
+
+[database]
+# The name of the database backend to use.
+# This must match an entry point in the 'py_load_opentargets.backends' group.
+backend = "postgres"
+# Separator to use when creating column names for flattened struct fields.
+# e.g., 'ancestors' struct with 'id' field becomes 'ancestors_id'.
+flatten_separator = "_"
+
+[source]
+# The active data source provider.
+# Can be "gcs_ftp" for the public Open Targets sources or "s3" for a private mirror.
+provider = "gcs_ftp"
+
+# Configuration for the default Google Cloud Storage and FTP sources.
+[source.gcs_ftp]
+version_discovery_uri = "ftp://ftp.ebi.ac.uk/pub/databases/opentargets/platform/"
+checksum_uri_template = "ftp://ftp.ebi.ac.uk/pub/databases/opentargets/platform/{version}/"
+# This template points to the directory containing all dataset directories.
+dataset_discovery_uri_template = "gcs://open-targets/platform/{version}/output/etl/parquet/"
+# Note: The 'data_uri_template' is used for streaming/remote operations,
+# while 'data_download_uri_template' could be different if downloads should
+# come from a different source (e.g. GCS for speed). If download template is
+# missing, it falls back to the main data_uri_template.
+data_uri_template = "gcs://open-targets/platform/{version}/output/etl/parquet/{dataset_name}/"
+data_download_uri_template = "gcs://open-targets/platform/{version}/output/etl/parquet/{dataset_name}/"
+
+# Configuration for using a private S3 bucket as the data source.
+# To use this, set 'provider = "s3"' above.
+# You must also install the S3 dependency: pip install .[s3]
+# Your environment must be configured with AWS credentials.
+[source.s3]
+version_discovery_uri = "s3://your-opentargets-bucket/platform/"
+checksum_uri_template = "s3://your-opentargets-bucket/platform/{version}/"
+dataset_discovery_uri_template = "s3://your-opentargets-bucket/platform/{version}/output/etl/parquet/"
+data_uri_template = "s3://your-opentargets-bucket/platform/{version}/output/etl/parquet/{dataset_name}/"
+data_download_uri_template = "s3://your-opentargets-bucket/platform/{version}/output/etl/parquet/{dataset_name}/"
+
+
+# Definitions for each dataset to be loaded.
+# Each dataset needs a 'primary_key' list for the merge (UPSERT) operation.
+# An optional 'final_table_name' can be provided to override the default,
+# which is the dataset name itself (with '-' replaced by '_').
+[datasets]
+
+[datasets.targets]
+primary_key = ["id"]
+# The 'schema_overrides' table provides fine-grained control over how columns
+# are processed and mapped to the database schema.
+[datasets.targets.schema_overrides]
+  # For the 'id' column, rename it to 'target_id' in the final table.
+  id = { rename = "target_id" }
+  # The 'tep' column is a struct. 'action = "flatten"' will expand its
+  # sub-fields (e.g., 'uri', 'name') into new columns ('tep_uri', 'tep_name').
+  tep = { action = "flatten" }
+  # 'genomicLocation' is also a struct to be flattened.
+  genomicLocation = { action = "flatten" }
+  # 'obsoleteTerms' is an array of structs. 'action = "json"' will serialize
+  # the entire array into a single JSONB column for flexible querying.
+  obsoleteTerms = { action = "json" }
+
+[datasets.diseases]
+primary_key = ["id"]
+
+[datasets.drugs]
+# The 'id' column for drugs is the ChEMBL ID.
+primary_key = ["id"]
+
+[datasets.evidence]
+# Each evidence string has a unique ID.
+primary_key = ["id"]
+
+[datasets.molecule]
+primary_key = ["id"]
+final_table_name = "molecule"
+
+[datasets.mousePhenotypes]
+primary_key = ["targetId", "diseaseId"]
+final_table_name = "mouse_phenotypes"
+
+[datasets.associationByDatasourceDirect]
+primary_key = ["targetId", "diseaseId", "datasourceId"]
+final_table_name = "association_direct_by_datasource"
+
+[datasets.associationByDatasourceIndirect]
+primary_key = ["targetId", "diseaseId", "datasourceId"]
+final_table_name = "association_indirect_by_datasource"
+
+[datasets.associationByOverallDirect]
+primary_key = ["targetId", "diseaseId"]
+final_table_name = "association_direct_overall"
+
+[datasets.associationByOverallIndirect]
+primary_key = ["targetId", "diseaseId"]
+final_table_name = "association_indirect_overall"

--- a/docs/vignette.md
+++ b/docs/vignette.md
@@ -1,0 +1,186 @@
+# Vignette: A-to-Z guide to py-load-opentargets
+
+This guide provides a complete walkthrough of using the `py-load-opentargets`
+package, from sourcing data to loading it into your database using different
+strategies.
+
+## 1. Sourcing the Data
+
+The first step is to configure the package to find the Open Targets data. This is
+done in the `config.toml` file, under the `[source]` section. The package can
+source data from Google Cloud Storage (GCS), FTP, or a local filesystem mirror.
+
+### Default Configuration
+
+The default configuration points to the official Open Targets GCS and FTP servers.
+For most use cases, you won't need to change this.
+
+```toml
+[source]
+gcs_base_url = "gs://open-targets/platform/"
+ftp_host = "ftp.ebi.ac.uk"
+ftp_path = "/pub/databases/opentargets/platform/"
+data_uri_template = "gs://open-targets/platform/{version}/output/etl/parquet/{dataset_name}"
+data_download_uri_template = "gs://open-targets/platform/{version}/output/etl/parquet/{dataset_name}"
+checksum_uri_template = "gs://open-targets/platform/{version}/"
+```
+
+### Using a Local Mirror
+
+If you have a local mirror of the Open Targets data, you can point the loader to
+it by changing the `data_uri_template` and `data_download_uri_template` to use a `file://` scheme.
+
+For example, if your data is stored in `/data/opentargets`, you would change
+the configuration to:
+
+```toml
+[source]
+data_uri_template = "file:///data/opentargets/{version}/output/etl/parquet/{dataset_name}"
+data_download_uri_template = "file:///data/opentargets/{version}/output/etl/parquet/{dataset_name}"
+```
+
+## 2. Loading Data into a Database
+
+Once the data source is configured, you can load the data into your database.
+
+### Database Connection
+
+The package requires a database connection string to be set as an environment
+variable named `DB_CONN_STR`. This is to avoid storing credentials in the
+configuration file.
+
+For PostgreSQL, the connection string format is:
+`postgresql://user:password@host:port/database`
+
+You can set this in your shell like so:
+
+```bash
+export DB_CONN_STR="postgresql://user:password@host:port/database"
+```
+
+### Running the Loader
+
+With the connection string set and the `config.toml` file in place, you can run
+the loader.
+
+To load all datasets defined in your `config.toml`:
+
+```bash
+py_load_opentargets load
+```
+
+To load only specific datasets:
+
+```bash
+py_load_opentargets load targets diseases
+```
+
+By default, the loader will find the latest version of the Open Targets data and
+load it. You can specify a version with the `--version` flag:
+
+```bash
+py_load_opentargets --version 22.04 load
+```
+
+## 3. Full Refresh vs. Delta Load
+
+The `py-load-opentargets` package offers two main strategies for loading data:
+`full-refresh` and `delta`. You can choose the strategy using the `--load-type`
+command-line option.
+
+### Full Refresh
+
+A **full refresh** completely replaces the data in the target tables. For each
+dataset, the loader will:
+1.  Drop the existing final table if it exists.
+2.  Create a new, empty final table.
+3.  Load the new data into the final table.
+
+This strategy is useful when you want to start from a clean slate or when you
+don't need to preserve any existing data in the tables.
+
+To perform a full refresh, use the `--load-type full-refresh` flag:
+
+```bash
+py_load_opentargets --load-type full-refresh load
+```
+
+### Delta Load
+
+A **delta load** (the default behavior) is a more sophisticated strategy that
+merges the new data with the existing data in the final tables. For each dataset,
+the loader will:
+1.  Load the new data into a temporary staging table.
+2.  Compare the staging table with the final table based on the `primary_key`
+    defined in `config.toml`.
+3.  **Insert** new records that are in the new data but not in the final table.
+4.  **Update** existing records in the final table with the new data.
+5.  **Delete** records from the final table that are not present in the new data.
+
+This strategy is useful when you want to update your database with a new release
+of the Open Targets data without losing any existing data that is still relevant.
+
+To perform a delta load, you can either omit the `--load-type` flag (as it's the
+default) or specify it explicitly:
+
+```bash
+# This is the default behavior
+py_load_opentargets load
+
+# Explicitly specifying delta load
+py_load_opentargets --load-type delta load
+```
+
+## 4. Putting It All Together: A Complete Example
+
+Let's walk through a complete example of loading the `targets` and `diseases`
+datasets into a PostgreSQL database.
+
+### 1. Configuration
+
+First, create a `config.toml` file with the following content. This configuration
+defines the two datasets and their primary keys.
+
+```toml
+# config.toml
+
+[source]
+# Using default sources
+
+[datasets]
+
+[datasets.targets]
+primary_key = ["id"]
+
+[datasets.diseases]
+primary_key = ["id"]
+```
+
+### 2. Set Database Connection
+
+Ensure your `DB_CONN_STR` environment variable is set:
+
+```bash
+export DB_CONN_STR="postgresql://test:test@localhost:32772/test" # Replace with your actual connection string
+```
+
+### 3. Run the Loader
+
+Now, run the loader. We'll use the default delta load strategy.
+
+```bash
+py_load_opentargets load targets diseases
+```
+
+### 4. What Happens in the Database
+
+After the command completes, you will have two new tables in your database:
+`public.targets` and `public.diseases`.
+
+-   The `public.targets` table will contain all the target data from the latest
+    Open Targets release.
+-   The `public.diseases` table will contain all the disease data.
+
+If you run the same command again with a new release of Open Targets data, the
+loader will intelligently update these tables with the new data, inserting,
+updating, and deleting rows as necessary.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,3 +3,11 @@ theme:
   name: material
 repo_url: https://github.com/ohdsi/py_load_opentargets
 repo_name: ohdsi/py_load_opentargets
+
+nav:
+  - Home: index.md
+  - Getting Started: getting_started.md
+  - Vignette: vignette.md
+  - Configuration: configuration.md
+  - Architecture: architecture.md
+  - API Reference: api_reference.md


### PR DESCRIPTION
This commit introduces a new, detailed vignette that explains how to use the `py-load-opentargets` package. The vignette covers:

- How to source data from different locations (GCS, FTP, local).
- How to configure the database connection.
- How to run the data loader.
- A detailed explanation of the 'full-refresh' and 'delta' loading strategies.
- A complete, end-to-end example.

To support the vignette, this commit also:

- Adds a `config.toml` file to the root of the project to serve as a starting point for users.
- Updates `mkdocs.yml` to include the new vignette in the site navigation.