### PR TITLE
feat: Improve test coverage and measure in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         export PG_BIN=/usr/lib/postgresql/16/bin
         export PATH="$PATH:$PG_BIN"
-        python -m pytest
+        python -m pytest --cov=src/py_load_opentargets
 
   release:
     needs: build-and-test

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,44 @@
+import pytest
+import os
+from py_load_opentargets.config import load_config, get_config, _config
+
+def test_load_config_file_not_found():
+    """
+    Test that FileNotFoundError is raised when the config file does not exist.
+    """
+    with pytest.raises(FileNotFoundError):
+        load_config('non_existent_file.toml')
+
+def test_load_config_malformed_toml(tmp_path):
+    """
+    Test that TOMLDecodeError is raised when the config file is malformed.
+    """
+    malformed_toml = tmp_path / "malformed.toml"
+    malformed_toml.write_text("this is not valid toml")
+    with pytest.raises(Exception): # Using generic exception as tomllib is not directly imported
+        load_config(str(malformed_toml))
+
+def test_load_config_missing_provider_warning(caplog, tmp_path):
+    """
+    Test that a warning is logged when a provider is specified but no
+    corresponding config section is found.
+    """
+    config_with_missing_provider = tmp_path / "missing_provider.toml"
+    config_with_missing_provider.write_text("""
+[source]
+provider = "missing_provider"
+""")
+    load_config(str(config_with_missing_provider))
+    assert "Source provider 'missing_provider' is specified but no corresponding" in caplog.text
+
+def test_get_config_loads_defaults_when_not_loaded():
+    """
+    Test that get_config() loads the default configuration if it hasn't
+    been loaded yet.
+    """
+    global _config
+    _config = None  # Ensure config is not loaded
+    config = get_config()
+    assert config is not None
+    assert 'database' in config
+    assert 'backend' in config['database']


### PR DESCRIPTION
This commit improves the test coverage of the project by adding new tests for the `config.py` module. It also updates the CI/CD pipeline to measure code coverage on every run.

The new tests in `tests/test_config.py` cover the following scenarios:
- Loading a non-existent configuration file.
- Loading a malformed TOML configuration file.
- Handling a missing provider section in the configuration.
- Ensuring `get_config()` loads default settings correctly.

The `.github/workflows/ci.yml` file has been updated to run `pytest` with the `--cov=src/py_load_opentargets` flag, which will report code coverage for the main application code. This helps in maintaining and improving code quality over time.