### PR TITLE
feat: Add high-level programmatic API and refactor CLI

### DIFF
--- a/src/py_load_opentargets/__init__.py
+++ b/src/py_load_opentargets/__init__.py
@@ -1,0 +1,3 @@
+from .api import load_opentargets
+
+__all__ = ["load_opentargets"]

--- a/src/py_load_opentargets/api.py
+++ b/src/py_load_opentargets/api.py
@@ -1,0 +1,121 @@
+import logging
+from typing import List, Optional
+
+from .config import load_config
+from .data_acquisition import list_available_versions
+from .orchestrator import ETLOrchestrator
+from .validator import ValidationService
+from .logging_utils import setup_logging
+
+logger = logging.getLogger(__name__)
+
+
+def load_opentargets(
+    version: Optional[str] = None,
+    datasets: Optional[List[str]] = None,
+    config_path: Optional[str] = None,
+    staging_schema: str = "staging",
+    final_schema: str = "public",
+    skip_confirmation: bool = False,
+    continue_on_error: bool = True,
+    load_type: str = "delta",
+    json_logs: bool = False,
+):
+    """
+    Programmatic entry point for the Open Targets ETL process.
+
+    This function orchestrates the full ETL process for specified Open Targets
+    datasets, from data acquisition to loading into a database. It serves as the
+    main Python API for the package.
+
+    Note: This function requires the `DB_CONN_STR` environment variable to be set
+    with the target database connection string.
+
+    Args:
+        version (Optional[str]): The Open Targets release version to load (e.g., "22.04").
+            If None, the latest available version will be discovered and used. Defaults to None.
+        datasets (Optional[List[str]]): A list of specific dataset names to process.
+            If None, all datasets defined in the configuration file will be processed.
+            Defaults to None.
+        config_path (Optional[str]): Path to a custom `config.toml` file. If None, the
+            default packaged configuration is used. Defaults to None.
+        staging_schema (str): The name of the database schema to use for staging tables.
+            Defaults to "staging".
+        final_schema (str): The name of the database schema for the final, merged tables.
+            Defaults to "public".
+        skip_confirmation (bool): If True, skips the confirmation prompt when a version
+            has already been loaded. Defaults to False.
+        continue_on_error (bool): If True, the process will continue with other datasets
+            if one fails. If False, it will abort on the first error. Defaults to True.
+        load_type (str): The strategy for loading data. Can be "delta" (default) to
+            merge changes, or "full-refresh" to replace the table entirely.
+        json_logs (bool): If True, configures logging to output in JSON format.
+            Defaults to False.
+    """
+    # --- 1. Setup: Logging and Configuration ---
+    # Load config first to check for logging settings within the file.
+    try:
+        config = load_config(config_path)
+        use_json_logging = json_logs or config.get("logging", {}).get("json_format", False)
+        setup_logging(json_format=use_json_logging)
+
+        logger.info("--- Starting Open Targets ETL Process via Programmatic API ---")
+        source_config = config["source"]
+        all_defined_datasets = config["datasets"]
+        datasets_to_process = datasets or list(all_defined_datasets.keys())
+
+        logger.info(f"Selected datasets: {', '.join(datasets_to_process)}")
+        logger.info(f"Load type: {load_type}")
+        logger.info(f"Staging schema: '{staging_schema}', Final schema: '{final_schema}'")
+
+        # --- 2. Validation ---
+        logger.info("Validating configuration and connections...")
+        validator = ValidationService(config)
+        results = validator.run_all_checks()
+        all_successful = True
+        for check_name, result in results.items():
+            if not result["success"]:
+                all_successful = False
+                message = result["message"]
+                logger.error(f"Validation FAILED for '{check_name}': {message}")
+
+        if not all_successful:
+            logger.critical("Prerequisite validation failed. Please check your configuration.")
+            # Raising an exception is more idiomatic for an API than aborting.
+            raise RuntimeError("Prerequisite validation failed. Please check logs for details.")
+        else:
+            logger.info("Validation successful.")
+
+        # --- 3. Version Discovery ---
+        if not version:
+            logger.info("No version specified, discovering the latest...")
+            try:
+                versions = list_available_versions(source_config["version_discovery_uri"])
+                if not versions:
+                    raise RuntimeError("Could not find any available Open Targets versions.")
+                version = versions[0]
+                logger.info(f"Found latest version: {version}")
+            except Exception as e:
+                logger.critical(f"A fatal error occurred during version discovery: {e}")
+                raise  # Re-raise the exception to halt execution
+
+        # --- 4. Orchestration & Execution ---
+        logger.info(f"Preparing to load Open Targets version '{version}'.")
+        orchestrator = ETLOrchestrator(
+            config=config,
+            datasets_to_process=datasets_to_process,
+            version=version,
+            staging_schema=staging_schema,
+            final_schema=final_schema,
+            skip_confirmation=skip_confirmation,
+            continue_on_error=continue_on_error,
+            load_type=load_type,
+        )
+        orchestrator.run()
+
+    except Exception as e:
+        logger.critical(f"A fatal error occurred during the ETL process: {e}", exc_info=True)
+        # Re-raise the exception so the caller can handle it.
+        raise
+    finally:
+        logger.info("--- Programmatic API Process Finished ---")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,132 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from py_load_opentargets import api
+
+# A sample config for mocking load_config
+MOCK_CONFIG = {
+    "source": {
+        "version_discovery_uri": "mock://versions",
+        "provider": "mock_provider",
+        "mock_provider": {
+            "data_uri_template": "mock://{version}/{dataset_name}"
+        }
+    },
+    "database": {
+        "backend": "postgres"
+    },
+    "datasets": {
+        "dataset1": {"primary_key": ["id"]},
+        "dataset2": {"primary_key": ["id"]},
+    }
+}
+
+@patch("py_load_opentargets.api.setup_logging")
+@patch("py_load_opentargets.api.ETLOrchestrator")
+@patch("py_load_opentargets.api.ValidationService")
+@patch("py_load_opentargets.api.load_config", return_value=MOCK_CONFIG)
+def test_load_opentargets_api_direct_call(
+    mock_load_config, mock_validator, mock_orchestrator, mock_setup_logging
+):
+    """
+    Tests that the `load_opentargets` API function correctly calls the
+    ETLOrchestrator with the provided arguments.
+    """
+    # Arrange
+    # Mock the validator to simulate a successful validation
+    mock_validator_instance = MagicMock()
+    mock_validator_instance.run_all_checks.return_value = {"check1": {"success": True, "message": "OK"}}
+    mock_validator.return_value = mock_validator_instance
+
+    mock_orchestrator_instance = MagicMock()
+    mock_orchestrator.return_value = mock_orchestrator_instance
+
+    # Act
+    api.load_opentargets(
+        version="22.01",
+        datasets=["dataset1"],
+        config_path="/fake/path.toml",
+        staging_schema="test_staging",
+        final_schema="test_final",
+        load_type="full-refresh",
+        continue_on_error=False
+    )
+
+    # Assert
+    # Verify config was loaded with the correct path
+    mock_load_config.assert_called_once_with("/fake/path.toml")
+
+    # Verify validator was used
+    mock_validator.assert_called_once_with(MOCK_CONFIG)
+    mock_validator_instance.run_all_checks.assert_called_once()
+
+    # Verify orchestrator was instantiated with the correct parameters
+    mock_orchestrator.assert_called_once_with(
+        config=MOCK_CONFIG,
+        datasets_to_process=["dataset1"],
+        version="22.01",
+        staging_schema="test_staging",
+        final_schema="test_final",
+        skip_confirmation=False,  # Default value
+        continue_on_error=False,
+        load_type="full-refresh",
+    )
+
+    # Verify the main execution method was called
+    mock_orchestrator_instance.run.assert_called_once()
+
+
+@patch("py_load_opentargets.api.setup_logging")
+@patch("py_load_opentargets.api.list_available_versions", return_value=["23.06", "23.04"])
+@patch("py_load_opentargets.api.ETLOrchestrator")
+@patch("py_load_opentargets.api.ValidationService")
+@patch("py_load_opentargets.api.load_config", return_value=MOCK_CONFIG)
+def test_load_opentargets_api_version_discovery(
+    mock_load_config, mock_validator, mock_orchestrator, mock_list_versions, mock_setup_logging
+):
+    """
+    Tests that the API function performs version discovery when no version is provided
+    and passes the latest version to the orchestrator.
+    """
+    # Arrange
+    mock_validator_instance = MagicMock()
+    mock_validator_instance.run_all_checks.return_value = {"check1": {"success": True, "message": "OK"}}
+    mock_validator.return_value = mock_validator_instance
+
+    # Act
+    api.load_opentargets() # Call with no arguments to trigger defaults
+
+    # Assert
+    # Verify that version discovery was triggered
+    mock_list_versions.assert_called_once_with(MOCK_CONFIG["source"]["version_discovery_uri"])
+
+    # Verify that the latest version ("23.06") was passed to the orchestrator
+    mock_orchestrator.assert_called_once()
+    args, kwargs = mock_orchestrator.call_args
+    assert kwargs["version"] == "23.06"
+    # Verify it processes all datasets by default
+    assert kwargs["datasets_to_process"] == ["dataset1", "dataset2"]
+
+
+@patch("py_load_opentargets.api.setup_logging")
+@patch("py_load_opentargets.api.ETLOrchestrator")
+@patch("py_load_opentargets.api.ValidationService")
+@patch("py_load_opentargets.api.load_config", return_value=MOCK_CONFIG)
+def test_load_opentargets_api_validation_failure(
+    mock_load_config, mock_validator, mock_orchestrator, mock_setup_logging
+):
+    """
+    Tests that the API function raises a RuntimeError if validation fails.
+    """
+    # Arrange
+    # Mock the validator to simulate a failed validation
+    mock_validator_instance = MagicMock()
+    mock_validator_instance.run_all_checks.return_value = {"check1": {"success": False, "message": "Failed"}}
+    mock_validator.return_value = mock_validator_instance
+
+    # Act & Assert
+    with pytest.raises(RuntimeError, match="Prerequisite validation failed"):
+        api.load_opentargets(version="22.01")
+
+    # Verify that the orchestrator was NOT called
+    mock_orchestrator.assert_not_called()

--- a/tests/test_discovery_feature.py
+++ b/tests/test_discovery_feature.py
@@ -3,9 +3,19 @@ from unittest.mock import patch, MagicMock
 from click.testing import CliRunner
 
 from py_load_opentargets.data_acquisition import discover_datasets
-from py_load_opentargets.cli import cli
+from py_load_opentargets.cli import cli, load_config
 
-
+MOCK_CONFIG = {
+    "source": {
+        "version_discovery_uri": "mock://versions",
+        "provider": "mock_provider",
+        # This key is added to simulate the result of the dynamic provider logic in load_config
+        "data_uri_template": "mock://{version}/{dataset_name}",
+        "mock_provider": {
+            "data_uri_template": "mock://{version}/{dataset_name}"
+        }
+    }
+}
 @pytest.fixture
 def mock_fsspec_ls():
     """Fixture to patch fsspec.ls"""
@@ -59,27 +69,33 @@ def test_discover_datasets_exception(mock_fsspec_ls):
     assert datasets == []
 
 # Integration tests for CLI command
-@patch('py_load_opentargets.data_acquisition.discover_datasets')
-def test_cli_discover_datasets_list_format(mock_discover):
+@patch('py_load_opentargets.cli.load_config', return_value=MOCK_CONFIG)
+def test_cli_discover_datasets_list_format(mock_load_config, mock_fsspec_ls):
     """Test the CLI command with list format (default)."""
-    mock_discover.return_value = ['diseases', 'targets']
+    mock_fsspec_ls.return_value = [
+        {'name': 'mock_path/diseases', 'type': 'directory'},
+        {'name': 'mock_path/targets', 'type': 'directory'}
+    ]
     runner = CliRunner()
     result = runner.invoke(cli, ['discover-datasets', '--version', '24.06'])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"CLI command failed with output:\n{result.output}"
     assert "Available datasets:" in result.output
     assert "- diseases" in result.output
     assert "- targets" in result.output
     assert "[datasets.diseases]" not in result.output # Ensure TOML is not printed
 
-@patch('py_load_opentargets.data_acquisition.discover_datasets')
-def test_cli_discover_datasets_toml_format(mock_discover):
+@patch('py_load_opentargets.cli.load_config', return_value=MOCK_CONFIG)
+def test_cli_discover_datasets_toml_format(mock_load_config, mock_fsspec_ls):
     """Test the CLI command with toml format."""
-    mock_discover.return_value = ['diseases', 'association-by-datasrc']
+    mock_fsspec_ls.return_value = [
+        {'name': 'mock_path/diseases', 'type': 'directory'},
+        {'name': 'mock_path/association-by-datasrc', 'type': 'directory'}
+    ]
     runner = CliRunner()
     result = runner.invoke(cli, ['discover-datasets', '--version', '24.06', '--format', 'toml'])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"CLI command failed with output:\n{result.output}"
     assert "# Copy and paste" in result.output
     # Test case 1: No hyphen, no final_table_name expected
     assert '[datasets.diseases]' in result.output
@@ -88,14 +104,14 @@ def test_cli_discover_datasets_toml_format(mock_discover):
     assert '[datasets.association-by-datasrc]' in result.output
     assert 'final_table_name = "association_by_datasrc"' in result.output
 
-@patch('py_load_opentargets.data_acquisition.discover_datasets')
-def test_cli_discover_datasets_no_results(mock_discover):
+@patch('py_load_opentargets.cli.load_config', return_value=MOCK_CONFIG)
+def test_cli_discover_datasets_no_results(mock_load_config, mock_fsspec_ls):
     """Test the CLI command when no datasets are found."""
-    mock_discover.return_value = []
+    mock_fsspec_ls.return_value = []
     runner = CliRunner()
     result = runner.invoke(cli, ['discover-datasets', '--version', '00.00'])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"CLI command failed with output:\n{result.output}"
     assert "Could not find any datasets" in result.output
 
 def test_cli_discover_datasets_missing_version():


### PR DESCRIPTION
This change introduces a new high-level programmatic API for the package, addressing the gap identified in the FRD (R.3.5.2).

Key changes:

- A new `api.py` module is created with a public `load_opentargets()` function. This function encapsulates the entire ETL orchestration logic, providing a simple and stable entry point for developers.
- The `cli.py` module is refactored. The `load` command now acts as a thin wrapper around the new `api.load_opentargets()` function, which centralizes the core logic and reduces code duplication.
- Other CLI commands (`discover-datasets`, `validate`) are updated to handle logging and configuration loading correctly after the refactoring.
- The `__init__.py` file is updated to expose `load_opentargets` at the top level of the package.
- A new test file, `tests/test_api.py`, is added with comprehensive unit tests for the new API function, using mocking to ensure it's tested in isolation.
- Existing tests in `tests/test_discovery_feature.py` and `tests/test_new_cli_integration.py` that were broken by the refactoring have been fixed.
- The API documentation (`docs/api_reference.md`) has been completely rewritten to reflect the new, user-friendly API function.