### PR TITLE
Add pytest-cov to test dependencies (#65)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ test = [
     "gcsfs>=2023.9.0",
     "sqlalchemy>=2.0.43",
     "psycopg2-binary>=2.9.10",
+    "pytest-cov",
 ]
 
 [tool.poetry.group.docs.dependencies]


### PR DESCRIPTION
This adds the `pytest-cov` package to the test dependencies in `pyproject.toml`. This package is required to generate code coverage reports when running the test suite.