### PR TITLE
Fix: Correct test dependencies to unbreak the CI pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ gcs = ["gcsfs"]
 s3 = ["s3fs"]
 all = ["gcsfs", "s3fs"]
 test = [
+    "pyyaml==6.0.1",
+    "cython<3",
     "testcontainers[postgres]>=4.5.0",
     "pytest>=7.4.2",
     "pytest-mock>=3.11.1",
@@ -47,7 +49,6 @@ test = [
     "sqlalchemy>=2.0.43",
     "psycopg2-binary>=2.9.10",
     "pytest-cov",
-    "cython",
 ]
 
 [tool.poetry.group.docs.dependencies]


### PR DESCRIPTION
The CI pipeline was failing during the `pip install -e .[test]` step due to a dependency conflict with `PyYAML` and `Cython`.

This change fixes the issue by pinning `pyyaml` to version `6.0.1` and `cython` to a version less than 3 in the `[project.optional-dependencies.test]` section of `pyproject.toml`. This resolves the build error (`AttributeError: cython_sources`) and allows the existing GitHub Actions workflow to run successfully.

No changes were needed for the `.github/workflows/ci.yml` file itself, as the issue was with the dependencies, not the workflow definition.