### PR TITLE
fix(lint): Resolve all ruff linting errors (#71)

### DIFF
--- a/explore_versions.py
+++ b/explore_versions.py
@@ -1,5 +1,4 @@
 import fsspec
-import re
 from pathlib import Path
 
 # Using a hardcoded recent version to avoid repeated FTP listing

--- a/src/py_load_opentargets/backends/postgres.py
+++ b/src/py_load_opentargets/backends/postgres.py
@@ -1,12 +1,11 @@
 import psycopg
 from psycopg import sql
-import pyarrow.parquet as pq
 import pyarrow as pa
 import polars as pl
 import logging
 import io
 import json
-from typing import Dict, Any, Iterator, List, Optional
+from typing import Dict, Any, List, Optional
 
 from ..loader import DatabaseLoader
 
@@ -238,7 +237,7 @@ class PostgresLoader(DatabaseLoader):
         logger.info(f"Starting single-stream bulk load for '{table_name}'.")
 
         if not parquet_uris:
-            logger.warning(f"No .parquet files provided. Skipping bulk load.")
+            logger.warning("No .parquet files provided. Skipping bulk load.")
             return 0
 
         schema_overrides = self.dataset_config.get("schema_overrides", {})

--- a/src/py_load_opentargets/config.py
+++ b/src/py_load_opentargets/config.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import collections.abc
 from typing import Dict, Any, Optional

--- a/src/py_load_opentargets/validator.py
+++ b/src/py_load_opentargets/validator.py
@@ -3,7 +3,6 @@ import logging
 from typing import Dict, Any
 
 import psycopg
-import fsspec
 
 from .data_acquisition import list_available_versions
 

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -1,6 +1,6 @@
 import pytest
 import hashlib
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock
 from pathlib import Path
 
 from py_load_opentargets.data_acquisition import get_checksum_manifest, download_dataset, _verify_file_checksum, _download_and_verify_one_file
@@ -62,7 +62,6 @@ def test_get_checksum_manifest_mismatch(mock_fsspec_open):
 
     # Prepare mock data with a deliberate mismatch
     manifest_data = "some data"
-    correct_hash = hashlib.sha1(manifest_data.encode()).hexdigest()
     wrong_hash = "wrong_hash"
     checksum_file_content = f"{wrong_hash}  release_data_integrity"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 import pytest
-import os
-from py_load_opentargets.config import load_config, get_config, _config
+from py_load_opentargets.config import load_config, get_config
 
 def test_load_config_file_not_found():
     """

--- a/tests/test_config_extended.py
+++ b/tests/test_config_extended.py
@@ -1,4 +1,3 @@
-import pytest
 from py_load_opentargets.config import deep_merge, load_config
 
 def test_deep_merge_simple():

--- a/tests/test_data_acquisition_integration.py
+++ b/tests/test_data_acquisition_integration.py
@@ -1,9 +1,8 @@
 import pytest
 from pathlib import Path
-import os
 import hashlib
 
-from py_load_opentargets.data_acquisition import list_available_versions, get_checksum_manifest, download_dataset
+from py_load_opentargets.data_acquisition import list_available_versions, get_checksum_manifest
 
 # --- Configuration ---
 

--- a/tests/test_discovery_feature.py
+++ b/tests/test_discovery_feature.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 from click.testing import CliRunner
 
 from py_load_opentargets.data_acquisition import discover_datasets
-from py_load_opentargets.cli import cli, load_config
+from py_load_opentargets.cli import cli
 
 MOCK_CONFIG = {
     "source": {

--- a/tests/test_download_integration.py
+++ b/tests/test_download_integration.py
@@ -1,10 +1,8 @@
-import pytest
 import pyarrow as pa
 import pyarrow.parquet as pq
 from pathlib import Path
 from unittest.mock import patch
 import hashlib
-import os
 
 from py_load_opentargets.orchestrator import ETLOrchestrator
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,4 +1,3 @@
-import pytest
 import pyarrow as pa
 import pyarrow.parquet as pq
 from pathlib import Path

--- a/tests/test_foreign_key_handling.py
+++ b/tests/test_foreign_key_handling.py
@@ -2,7 +2,6 @@ import pytest
 from testcontainers.postgres import PostgresContainer
 from testcontainers.core.wait_strategies import LogMessageWaitStrategy
 import psycopg
-from psycopg import sql
 
 from py_load_opentargets.backends.postgres import PostgresLoader
 

--- a/tests/test_new_checksum_feature.py
+++ b/tests/test_new_checksum_feature.py
@@ -1,6 +1,6 @@
 import pytest
 import hashlib
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, mock_open
 
 # Functions to test
 from py_load_opentargets.data_acquisition import (

--- a/tests/test_new_cli_integration.py
+++ b/tests/test_new_cli_integration.py
@@ -1,11 +1,12 @@
 import pytest
-import os
 import psycopg
 from unittest.mock import MagicMock
 import pyarrow as pa
 import pyarrow.parquet as pq
 from pathlib import Path
 from click.testing import CliRunner
+import logging
+import json
 
 from py_load_opentargets.cli import cli
 
@@ -115,8 +116,6 @@ def mock_data_acquisition(monkeypatch, tmp_path: Path):
     monkeypatch.setattr("py_load_opentargets.orchestrator.download_dataset", mock_download)
     monkeypatch.setattr("py_load_opentargets.orchestrator.get_checksum_manifest", mock_get_checksum_manifest)
 
-import logging
-
 
 @pytest.fixture
 def mock_plain_logging(monkeypatch):
@@ -222,7 +221,6 @@ def test_cli_flattening(db_conn, db_conn_str, mock_data_acquisition, test_config
     final_data = cursor.fetchall()
 
     # The 'other_nested' column should be valid JSON
-    import json
     # psycopg may return JSONB as a string or a dict depending on version/context.
     # Handle both cases for robust testing.
     parsed_data = [
@@ -372,8 +370,6 @@ def test_load_command_fails_on_invalid_config(
     # 3. Assert that the main orchestrator logic was NOT called
     mock_orchestrator_run.assert_not_called()
 
-
-import json
 
 def test_cli_json_logging_flag(db_conn_str, mock_data_acquisition, test_config):
     """

--- a/tests/test_postgres_backend.py
+++ b/tests/test_postgres_backend.py
@@ -3,6 +3,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+import time
 from py_load_opentargets.backends.postgres import PostgresLoader
 from py_load_opentargets.data_acquisition import get_remote_schema
 
@@ -86,10 +87,6 @@ def test_generate_create_table_sql(loader):
 # --- Integration Tests ---
 # These tests require a running PostgreSQL database.
 # Set the DB_CONN_STR environment variable to run them.
-import os
-import psycopg
-import pyarrow.parquet as pq
-from pathlib import Path
 
 
 @pytest.fixture
@@ -104,8 +101,6 @@ def test_loader(db_conn):
     # Cleanup: rollback any transaction
     db_conn.rollback()
 
-
-import time
 
 def test_metadata_tracking(test_loader):
     """Tests the metadata creation and update functionality."""

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import psycopg
 from unittest.mock import MagicMock


### PR DESCRIPTION
This commit addresses all linting errors reported by `ruff`, including:
- F401 (unused import)
- F541 (f-string without placeholders)
- F841 (local variable assigned but not used)
- F811 (redefinition of unused name)
- E402 (module level import not at top of file)

Additionally, this commit resolves test failures that were occurring due to the package's entry points not being discoverable. This was fixed by ensuring the package is installed in editable mode (`pip install -e .`) before running the tests, which is the standard practice for this repository.